### PR TITLE
Make a3m transfers configurable

### DIFF
--- a/enduro.toml
+++ b/enduro.toml
@@ -65,6 +65,23 @@ bucket = "aips"
 address = "127.0.0.1:7000"
 shareDir = "/home/a3m/.local/share/a3m/share"
 
+[a3m.processing]
+AssignUuidsToDirectories                     = true
+ExamineContents                              = true
+GenerateTransferStructureReport              = true
+DocumentEmptyDirectories                     = true
+ExtractPackages                              = true
+DeletePackagesAfterExtraction                = true
+IdentifyTransfer                             = true
+IdentifySubmissionAndMetadata                = true
+IdentifyBeforeNormalization                  = true
+Normalize                                    = true
+TranscribeFiles                              = true
+PerformPolicyChecksOnOriginals               = true
+PerformPolicyChecksOnPreservationDerivatives = true
+AipCompressionLevel                          = 1
+AipCompressionAlgorithm                      = 6
+
 [upload]
 endpoint = "http://minio.enduro-sdps:9000"
 pathStyle = true

--- a/go.work.sum
+++ b/go.work.sum
@@ -78,16 +78,5 @@ go.etcd.io/etcd/client/v2 v2.305.7/go.mod h1:GQGT5Z3TBuAQGvgPfhR7VPySu/SudxmEkRq
 go.etcd.io/etcd/client/v3 v3.5.9/go.mod h1:i/Eo5LrZ5IKqpbtpPDuaUnDOUv471oDg8cjQaUr2MbA=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.0.1/go.mod h1:B1r9v/IqMtkB0lIGbbayqT6f2awSH0EDZya1Yu4p1pU=
 go.opentelemetry.io/otel/internal/metric v0.24.0/go.mod h1:PSkQG+KuApZjBpC6ea6082ZrWUUy/w132tJ/LOU3TXk=
-golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-modernc.org/b v1.0.0/go.mod h1:uZWcZfRj1BpYzfN9JTerzlNUnnPsV9O2ZA8JsRcubNg=
-modernc.org/db v1.0.0/go.mod h1:kYD/cO29L/29RM0hXYl4i3+Q5VojL31kTUVpVJDw0s8=
-modernc.org/file v1.0.0/go.mod h1:uqEokAEn1u6e+J45e54dsEA/pw4o7zLrA2GwyntZzjw=
-modernc.org/fileutil v1.0.0/go.mod h1:JHsWpkrk/CnVV1H/eGlFf85BEpfkrp56ro8nojIq9Q8=
-modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
-modernc.org/internal v1.0.0/go.mod h1:VUD/+JAkhCpvkUitlEOnhpVxCgsBI90oTzSCRcqQVSM=
-modernc.org/lldb v1.0.0/go.mod h1:jcRvJGWfCGodDZz8BPwiKMJxGJngQ/5DrRapkQnLob8=
-modernc.org/ql v1.0.0/go.mod h1:xGVyrLIatPcO2C1JvI/Co8c0sr6y91HKFNy4pt9JXEY=
-modernc.org/sortutil v1.1.0/go.mod h1:ZyL98OQHJgH9IEfN71VsamvJgrtRX9Dj2gX+vH86L1k=
-modernc.org/zappy v1.0.0/go.mod h1:hHe+oGahLVII/aTTyWK/b53VDHMAGCBYYeZ9sn83HC4=

--- a/internal/a3m/config.go
+++ b/internal/a3m/config.go
@@ -1,6 +1,49 @@
 package a3m
 
+import transferservice "buf.build/gen/go/artefactual/a3m/protocolbuffers/go/a3m/api/transferservice/v1beta1"
+
 type Config struct {
-	Address  string
+	Address string
+	Name    string
+	Processing
 	ShareDir string
+}
+
+// The `Processing` struct represents a configuration for processing various tasks in the transferservice.
+// It mirrors the processing configuration fields in transferservice.ProcessingConfig.
+type Processing struct {
+	AssignUuidsToDirectories                     bool
+	ExamineContents                              bool
+	GenerateTransferStructureReport              bool
+	DocumentEmptyDirectories                     bool
+	ExtractPackages                              bool
+	DeletePackagesAfterExtraction                bool
+	IdentifyTransfer                             bool
+	IdentifySubmissionAndMetadata                bool
+	IdentifyBeforeNormalization                  bool
+	Normalize                                    bool
+	TranscribeFiles                              bool
+	PerformPolicyChecksOnOriginals               bool
+	PerformPolicyChecksOnPreservationDerivatives bool
+	AipCompressionLevel                          int
+	AipCompressionAlgorithm                      transferservice.ProcessingConfig_AIPCompressionAlgorithm
+}
+
+// Set the defaults for the a3m transfer service.
+var ProcessingDefault = Processing{
+	AssignUuidsToDirectories:                     true,
+	ExamineContents:                              false,
+	GenerateTransferStructureReport:              true,
+	DocumentEmptyDirectories:                     true,
+	ExtractPackages:                              true,
+	DeletePackagesAfterExtraction:                false,
+	IdentifyTransfer:                             true,
+	IdentifySubmissionAndMetadata:                true,
+	IdentifyBeforeNormalization:                  true,
+	Normalize:                                    true,
+	TranscribeFiles:                              true,
+	PerformPolicyChecksOnOriginals:               true,
+	PerformPolicyChecksOnPreservationDerivatives: true,
+	AipCompressionLevel:                          1,
+	AipCompressionAlgorithm:                      transferservice.ProcessingConfig_AIP_COMPRESSION_ALGORITHM_S7_BZIP2,
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ func Read(config *Configuration, configFile string) (found bool, configFileUsed 
 	v.AddConfigPath("$HOME/.config/")
 	v.AddConfigPath("/etc")
 	v.SetConfigName("enduro")
+	v.SetDefault("api.processing", a3m.ProcessingDefault)
 	v.SetDefault("debugListen", "127.0.0.1:9001")
 	v.SetDefault("api.listen", "127.0.0.1:9000")
 	v.SetEnvPrefix("enduro")


### PR DESCRIPTION
Change hardcoded enduro string to config
Add default name
Add configuration settings to toml
The toml settings are an example to try out
Set viper defaults
Change transferservicev1beta to transferservice.
Remove name configurablility and replace with constant. Set a default struct in a3m package